### PR TITLE
fix_calculator #156

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://zibitz.shop/v1
+VITE_API_BASE_URL=http://15.165.143.27/v1

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://zibitz.shop/v1
+VITE_API_BASE_URL=http://15.165.143.27/v1

--- a/src/pages/scores/Step1_HouseOwnership.vue
+++ b/src/pages/scores/Step1_HouseOwnership.vue
@@ -5,6 +5,7 @@
         <div class="flex justify-start pb-4">
             <span class="text-lg text-gray-500">1/6</span>
         </div>
+
         <div class="flex items-center mb-6">
             <div>
                 <h1 class="text-xl font-extrabold mb-1">주택 소유 기준</h1>
@@ -37,7 +38,6 @@
         </div>
 
         <div class="space-y-4">
-            <!-- "소유 중" 을 눌렀을 때 1, "무주택" 을 눌렀을 때 0 으로 저장 -->
             <button @click="select('owner')" :class="btnClass('owner')">소유 중</button>
             <button @click="select('no-house')" :class="btnClass('no-house')">무주택</button>
         </div>
@@ -57,12 +57,12 @@ import PrimaryButton from '@/components/common/PrimaryButton.vue'
 const router = useRouter()
 const scoreStore = useScoreStore()
 
-// 'owner' ↔ 1, 'no-house' ↔ 0
+// 초기 선택값 설정
 const selected = ref(
     scoreStore.houseOwner === 1 ? 'owner' : scoreStore.houseOwner === 0 ? 'no-house' : '',
 )
 
-// 버튼 클릭 시 store.houseOwner 에 숫자로 저장
+// 버튼 클릭 시 store 값 변경
 function select(val) {
     selected.value = val
     scoreStore.houseOwner = val === 'owner' ? 1 : 0

--- a/src/pages/scores/Step2_DisposalHistory.vue
+++ b/src/pages/scores/Step2_DisposalHistory.vue
@@ -5,6 +5,7 @@
         <div class="flex justify-start pb-4">
             <span class="text-lg text-gray-500">2/6</span>
         </div>
+
         <div class="flex items-center mb-6">
             <h2 class="text-lg font-bold">주택 혹은 분양권을 처분한 적이 있나요?</h2>
             <InfoTooltip title="주택 및 분양권 처분 내역">
@@ -20,7 +21,7 @@
             <button @click="select('no')" :class="btnClass('no')">아니요</button>
         </div>
 
-        <div v-if="selected === 'yes'" class="mt-6">
+        <div v-if="selected.value === 'yes'" class="mt-6">
             <label class="block mb-2 text-sm font-medium text-gray-700">처분한 연월</label>
             <input
                 v-model="disposedDate"
@@ -48,18 +49,16 @@ import PrimaryButton from '@/components/common/PrimaryButton.vue'
 const router = useRouter()
 const scoreStore = useScoreStore()
 
-// 초기 값: store.houseDisposal === 1 → 'yes', === 0 → 'no', else ''
 const selected = ref(
     scoreStore.houseDisposal === 1 ? 'yes' : scoreStore.houseDisposal === 0 ? 'no' : '',
 )
-// 로컬로 입력할 처분 연월
+
 const disposedDate = ref(scoreStore.disposalDate || '')
 
 function select(val) {
     selected.value = val
-    // 'yes' → 1, 'no' → 0
     scoreStore.houseDisposal = val === 'yes' ? 1 : 0
-    // 만약 'no' 선택 시 이전 날짜 삭제
+
     if (val === 'no') {
         disposedDate.value = ''
         scoreStore.disposalDate = ''
@@ -83,10 +82,8 @@ function next() {
             alert('처분한 연월을 입력해주세요.')
             return
         }
-        // store에 반영
         scoreStore.disposalDate = disposedDate.value
     } else {
-        // 'no' 선택 시 빈값
         scoreStore.disposalDate = null
     }
 

--- a/src/pages/scores/Step3_HouseholdHead.vue
+++ b/src/pages/scores/Step3_HouseholdHead.vue
@@ -5,6 +5,7 @@
         <div class="flex justify-start pb-4">
             <span class="text-lg text-gray-500">3/6</span>
         </div>
+
         <div class="flex items-center mb-6">
             <h2 class="text-lg font-bold">본인이 세대주이신가요?</h2>
             <InfoTooltip title="세대주 기준">
@@ -14,10 +15,12 @@
                 </ul>
             </InfoTooltip>
         </div>
+
         <div class="space-y-4">
             <button @click="select('yes')" :class="btnClass('yes')">네</button>
             <button @click="select('no')" :class="btnClass('no')">아니요</button>
         </div>
+
         <PrimaryButton class="mt-8" @click="next">다음</PrimaryButton>
     </ScoreStepWrapper>
 </template>
@@ -33,14 +36,12 @@ import PrimaryButton from '@/components/common/PrimaryButton.vue'
 const router = useRouter()
 const scoreStore = useScoreStore()
 
-// 초기값: 1 → 'yes', 0 → 'no', 그 외 → ''
 const selected = ref(
     scoreStore.headOfHousehold === 1 ? 'yes' : scoreStore.headOfHousehold === 0 ? 'no' : '',
 )
 
 function select(val) {
     selected.value = val
-    // 'yes' → 1, 'no' → 0
     scoreStore.headOfHousehold = val === 'yes' ? 1 : 0
 }
 

--- a/src/pages/scores/Step4.vue
+++ b/src/pages/scores/Step4.vue
@@ -11,12 +11,13 @@
                 <p>혼인 여부는 서류상 기준이며, 사실혼도 인정받을 수 있어요.</p>
             </InfoTooltip>
         </div>
+
         <div class="space-y-4">
             <button @click="select('yes')" :class="btnClass('yes')">네</button>
             <button @click="select('no')" :class="btnClass('no')">아니요</button>
         </div>
 
-        <div v-if="selected === 'yes'" class="mt-6">
+        <div v-if="selected.value === 'yes'" class="mt-6">
             <label class="block mb-2 text-sm font-medium text-gray-700">혼인 신고 연월</label>
             <input
                 v-model="marriageDate"
@@ -41,18 +42,16 @@ import PrimaryButton from '@/components/common/PrimaryButton.vue'
 const router = useRouter()
 const scoreStore = useScoreStore()
 
-// 초기값 설정: 1→'yes', 0→'no'
 const selected = ref(
     scoreStore.maritalStatus === 1 ? 'yes' : scoreStore.maritalStatus === 0 ? 'no' : '',
 )
-// 기존 저장된 날짜가 있으면 초기값으로
+
 const marriageDate = ref(scoreStore.weddingDate || '')
 
 function select(val) {
     selected.value = val
-    // 'yes'→1, 'no'→0
     scoreStore.maritalStatus = val === 'yes' ? 1 : 0
-    // 'no' 선택 시 날짜 초기화
+
     if (val === 'no') {
         marriageDate.value = ''
         scoreStore.weddingDate = null
@@ -76,10 +75,8 @@ function next() {
             alert('혼인 신고 연월을 입력해주세요.')
             return
         }
-        // store에 저장
         scoreStore.weddingDate = marriageDate.value
     } else {
-        // 'no'인 경우 null
         scoreStore.weddingDate = null
     }
 

--- a/src/pages/scores/Step5_DependentFamily.vue
+++ b/src/pages/scores/Step5_DependentFamily.vue
@@ -5,6 +5,7 @@
         <div class="flex justify-start pb-4">
             <span class="text-lg text-gray-500">5/6</span>
         </div>
+
         <!-- 헤드라인 -->
         <div class="px-4 pb-4">
             <h2 class="text-xl font-bold">부양가족을 선택해주세요</h2>
@@ -37,10 +38,10 @@
                 </div>
                 <div class="flex items-center gap-2">
                     <button
-                        @click="spouse = 1"
+                        @click="spouse.value = 1"
                         :class="[
                             'w-10 h-8 rounded-full border font-medium',
-                            spouse === 1
+                            spouse.value === 1
                                 ? 'bg-blue-500 text-white border-blue-500'
                                 : 'bg-gray-100 text-gray-700 border-gray-200',
                         ]"
@@ -48,10 +49,10 @@
                         O
                     </button>
                     <button
-                        @click="spouse = 0"
+                        @click="spouse.value = 0"
                         :class="[
                             'w-10 h-8 rounded-full border font-medium',
-                            spouse === 0
+                            spouse.value === 0
                                 ? 'bg-blue-500 text-white border-blue-500'
                                 : 'bg-gray-100 text-gray-700 border-gray-200',
                         ]"
@@ -128,13 +129,11 @@ import DependentCounter from '@/components/score/DependentCounter.vue'
 const router = useRouter()
 const scoreStore = useScoreStore()
 
-// 로컬 상태
-const spouse = ref(0) // 1 or 0
-const parents = ref(0) // integer
-const children = ref(0) // integer
+const spouse = ref(0)
+const parents = ref(0)
+const children = ref(0)
 
 function next() {
-    // 총합 계산하여 store.dependentsNm 에 저장
     scoreStore.dependentsNm = spouse.value + parents.value + children.value
     router.push('/score/step6')
 }

--- a/src/pages/scores/Step6_ResidenceInfo.vue
+++ b/src/pages/scores/Step6_ResidenceInfo.vue
@@ -19,7 +19,7 @@
         <!-- 입력 부분 -->
         <div class="space-y-4">
             <input
-                v-model="localDate"
+                v-model="scoreStore.residenceStartDate"
                 type="month"
                 class="w-full border px-4 py-2 rounded"
                 placeholder="거주 시작 연월"
@@ -31,7 +31,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useScoreStore } from '@/stores/scoreStore'
 import ScoreStepWrapper from '@/components/score/ScoreStepWrapper.vue'
@@ -40,23 +40,15 @@ import PrimaryButton from '@/components/common/PrimaryButton.vue'
 
 const router = useRouter()
 const scoreStore = useScoreStore()
-
-// EditStep6과 동일한 로컬 ref 사용
-const localDate = ref(scoreStore.residenceStartDate)
 const loading = ref(false)
 
-// (선택) 입력값 변경 감지 로그
-watch(localDate, (v) => console.log('[Step6] localDate →', v))
-
 async function onSubmit() {
-    // 1) 로컬 ref → store, localStorage 동기화
-    console.log('[Step6] saving residenceStartDate=', localDate.value)
-    scoreStore.residenceStartDate = localDate.value
-    localStorage.setItem('residenceStartDate', localDate.value)
-
-    // 2) 계산 호출
     loading.value = true
     try {
+        if (!scoreStore.residenceStartDate) {
+            alert('거주 시작 연월을 입력해 주세요.')
+            return
+        }
         await scoreStore.calculateScore()
         router.push('/score/result')
     } catch (e) {


### PR DESCRIPTION
## 📌 PR 제목 예시
fix: 가점 계산기 수정

---

## ✨ 변경 사항
- 가점 계산 수정됐고, 로그아웃 후 재로그인 시 유지되며 다른 계정으로 들어간다고 예전 계정 정보 남아있지 않아야 함!

---

## 🧪 테스트 방법
1. 계정 1로 로그인해서 가점정보 입력해보고, 로그아웃 후 재로그인 시 점수 유지되는 거 확인
2. 그리고 정보 수정해서 다시 저장 후 로그아웃, 재로그인 시 바뀐 점수 그대로 있는지 확인
3. 다시 로그아웃 후 계정 2로 들어갔을 때 게정 1의 점수가 아닌 계정 2의 점수가 뜨는지 확인 
---

## 🔍 관련 이슈
#156
---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
